### PR TITLE
Fix incorrect icon name for outdoor temperature

### DIFF
--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -490,7 +490,7 @@ def create_instruments():
         Sensor(
             attr="outdoor_temperature",
             name="Outdoor Temperature",
-            icon="mdi:mdiTemperatureCelsius",
+            icon="mdi:temperature-celsius",
             unit="°C",
         ),
         Sensor(attr="preheater_duration", name="Preheater runtime", icon="mdi:clock", unit="Min"),


### PR DESCRIPTION
Fix incorrect icon name for outdoor temperature